### PR TITLE
Expand Rust bit utilities

### DIFF
--- a/rust/mp4ff-rs/Cargo.toml
+++ b/rust/mp4ff-rs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mp4ff-rs"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]

--- a/rust/mp4ff-rs/src/bit_writer.rs
+++ b/rust/mp4ff-rs/src/bit_writer.rs
@@ -1,0 +1,89 @@
+use std::io::{self, Write};
+
+/// `BitWriter` accumulates bits and writes them to an underlying writer.
+#[derive(Debug)]
+pub struct BitWriter<W: Write> {
+    wr: W,
+    err: Option<io::Error>,
+    out: [u8; 1],
+    n: u32,
+    v: u32,
+}
+
+impl<W: Write> BitWriter<W> {
+    /// Create a new `BitWriter` that accumulates errors.
+    pub fn new(wr: W) -> Self {
+        Self { wr, err: None, out: [0], n: 0, v: 0 }
+    }
+
+    /// Write `n` bits from `bits`.
+    pub fn write(&mut self, bits: u32, n: u32) {
+        if self.err.is_some() {
+            return;
+        }
+        self.v <<= n;
+        self.v |= bits & super::mask(n);
+        self.n += n;
+        while self.n >= 8 {
+            let b = (self.v >> (self.n - 8)) & super::mask(8);
+            self.out[0] = b as u8;
+            if let Err(e) = self.wr.write_all(&self.out) {
+                self.err = Some(e);
+                return;
+            }
+            self.n -= 8;
+        }
+        self.v &= super::mask(8);
+    }
+
+    /// Flush remaining bits to the writer, padding with zeros.
+    pub fn flush(&mut self) {
+        if self.err.is_some() {
+            return;
+        }
+        if self.n != 0 {
+            let b = (self.v << (8 - self.n)) & super::mask(8);
+            self.out[0] = b as u8;
+            if let Err(e) = self.wr.write_all(&self.out) {
+                self.err = Some(e);
+                return;
+            }
+            self.n = 0;
+            self.v = 0;
+        }
+    }
+
+    /// Return the accumulated error if any.
+    pub fn acc_error(&self) -> Option<&io::Error> {
+        self.err.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BitWriter;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_writer() {
+        let cases = vec![
+            (vec![255u32], vec![0xffu8], 8),
+            (vec![15, 15], vec![0xffu8], 4),
+            (vec![3, 3, 3, 3], vec![0xffu8], 2),
+            (vec![1, 1, 1, 1, 1, 1, 1, 1], vec![0xffu8], 1),
+            (vec![15, 15, 15], vec![0xffu8, 0xf0u8], 4),
+            (vec![3, 3, 3, 3, 3, 3], vec![0xffu8, 0xf0u8], 2),
+        ];
+        for (inputs, want, size) in cases {
+            let mut buf = Cursor::new(Vec::new());
+            let mut w = BitWriter::new(&mut buf);
+            for bits in inputs {
+                w.write(bits, size);
+            }
+            assert!(w.acc_error().is_none());
+            w.flush();
+            assert!(w.acc_error().is_none());
+            assert_eq!(buf.into_inner(), want);
+        }
+    }
+}

--- a/rust/mp4ff-rs/src/lib.rs
+++ b/rust/mp4ff-rs/src/lib.rs
@@ -1,0 +1,158 @@
+use std::io::{self, Read};
+
+/// `BitReader` reads bits from an underlying reader and accumulates the first
+/// error that occurs. This is a minimal translation of the Go `bits.Reader`.
+#[derive(Debug)]
+pub struct BitReader<R: Read> {
+    rd: R,
+    err: Option<io::Error>,
+    n: u32,
+    value: u64,
+    pos: i64,
+}
+
+/// Mask for the `n` least significant bits.
+pub fn mask(n: u32) -> u32 {
+    if n == 32 {
+        u32::MAX
+    } else {
+        (1u32 << n) - 1
+    }
+}
+
+impl<R: Read> BitReader<R> {
+    /// Create a new `BitReader` that starts accumulating errors.
+    pub fn new(rd: R) -> Self {
+        Self { rd, err: None, n: 0, value: 0, pos: -1 }
+    }
+
+    /// Return the accumulated error if any.
+    pub fn acc_error(&self) -> Option<&io::Error> {
+        self.err.as_ref()
+    }
+
+    /// Read `n` bits and return them as the lowest bits of a `u32`.
+    /// If an error has occurred, 0 is returned.
+    pub fn read(&mut self, n: u32) -> u32 {
+        if self.err.is_some() {
+            return 0;
+        }
+        while self.n < n {
+            let mut buf = [0u8; 1];
+            match self.rd.read_exact(&mut buf) {
+                Ok(()) => {
+                    self.pos += 1;
+                    self.value = (self.value << 8) | u64::from(buf[0]);
+                    self.n += 8;
+                }
+                Err(e) => {
+                    self.err = Some(e);
+                    return 0;
+                }
+            }
+        }
+        let value = (self.value >> (self.n - n)) as u32;
+        self.n -= n;
+        self.value &= (1u64 << self.n) - 1;
+        value
+    }
+
+    /// Read `n` bits and interpret as a signed integer.
+    pub fn read_signed(&mut self, n: u32) -> i32 {
+        let v = self.read(n);
+        if n == 0 {
+            return 0;
+        }
+        let first = v >> (n - 1);
+        if first == 1 {
+            (v as i32) | (!0 << n)
+        } else {
+            v as i32
+        }
+    }
+
+    /// Read a single bit interpreted as a boolean flag.
+    pub fn read_flag(&mut self) -> bool {
+        self.read(1) == 1
+    }
+
+    /// Read remaining bytes if currently byte-aligned.
+    pub fn read_remaining_bytes(&mut self) -> Option<Vec<u8>> {
+        if self.err.is_some() {
+            return None;
+        }
+        if self.n != 0 {
+            self.err = Some(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "{} bit instead of byte alignment when reading remaining bytes",
+                    self.n
+                ),
+            ));
+            return None;
+        }
+        let mut rest = Vec::new();
+        if let Err(e) = self.rd.read_to_end(&mut rest) {
+            self.err = Some(e);
+            return None;
+        }
+        Some(rest)
+    }
+
+    /// Number of bytes read from the underlying reader.
+    pub fn nr_bytes_read(&self) -> i64 {
+        self.pos + 1
+    }
+
+    /// Total number of bits read.
+    pub fn nr_bits_read(&self) -> i64 {
+        let mut nr = self.nr_bytes_read() * 8;
+        if self.nr_bits_read_in_current_byte() != 8 {
+            nr += self.nr_bits_read_in_current_byte() - 8;
+        }
+        nr
+    }
+
+    /// Number of bits consumed in the current byte.
+    pub fn nr_bits_read_in_current_byte(&self) -> i64 {
+        8 - self.n as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BitReader, mask};
+    use std::io::Cursor;
+
+    #[test]
+    fn test_read_bits() {
+        let data = [0xffu8, 0x0f];
+        let mut r = BitReader::new(Cursor::new(&data));
+        assert_eq!(r.read(2), 3); // 11
+        assert_eq!(r.read(3), 7); // 111
+        assert_eq!(r.read(5), 28); // 11100
+        assert_eq!(r.read(3), 1); // 001
+        assert_eq!(r.read(3), 7); // 111
+        assert!(r.acc_error().is_none());
+    }
+
+    #[test]
+    fn test_read_signed_bits() {
+        let data = [0xffu8, 0x0c];
+        let mut r = BitReader::new(Cursor::new(&data));
+        assert_eq!(r.read_signed(2), -1);
+        assert_eq!(r.read_signed(3), -1);
+        assert_eq!(r.read_signed(5), -4);
+        assert_eq!(r.read_signed(3), 1);
+        assert_eq!(r.read_signed(3), -4);
+        assert!(r.acc_error().is_none());
+    }
+    #[test]
+    fn test_writer_mask() {
+        assert_eq!(mask(8), 0xff);
+        assert_eq!(mask(4), 0x0f);
+    }
+}
+
+mod bit_writer;
+pub use bit_writer::BitWriter;


### PR DESCRIPTION
## Summary
- extend the Rust crate with a bit writer and helper mask function
- add method for reading remaining bytes in `BitReader`
- add tests for the new Rust utilities

## Testing
- `cargo test` in `rust/mp4ff-rs`
- `go test ./...` *(fails: `Forbidden` network access)*

------
https://chatgpt.com/codex/tasks/task_e_684b46be26f8832ba182e028192a7742