### PR TITLE
Add Rust CLI to print MP4 metadata

### DIFF
--- a/rust/mp4ff-rs/src/main.rs
+++ b/rust/mp4ff-rs/src/main.rs
@@ -1,7 +1,34 @@
 
 
+//! Simple binary that prints metadata for an MP4 file.
+//!
+//! Usage: `cargo run -- [PATH_TO_MP4]`
+//!
+//! If no path is provided, the bundled `files/video.mp4` is used.
+
+use std::env;
+use std::path::PathBuf;
+
+use mp4ff::read_mp4_metadata;
+
 fn main() {
-    // This is a placeholder for the main function.
-    // write function to print metadata from a file
-    println!("Metadata read successfully.");
+    // Determine the file to read from the first CLI argument or fall back to
+    // the bundled sample file.
+    let args: Vec<String> = env::args().collect();
+    let path = if args.len() > 1 {
+        PathBuf::from(&args[1])
+    } else {
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("files/video.mp4");
+        p
+    };
+
+    match read_mp4_metadata(&path) {
+        Ok(md) => {
+            println!("Title: {:?}", md.title);
+            println!("Duration: {:?}", md.duration);
+            println!("Size: {} bytes", md.size);
+        }
+        Err(e) => eprintln!("Failed to read metadata: {e}"),
+    }
 }

--- a/rust/mp4ff-rs/src/metadata.rs
+++ b/rust/mp4ff-rs/src/metadata.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, BufReader, Cursor};
 use std::path::Path;
 
+/// Basic metadata extracted from an MP4 file.
 #[derive(Debug, Default, PartialEq)]
 pub struct Metadata {
     pub title: Option<String>,
@@ -52,6 +53,10 @@ fn read_box_header<R: Read>(r: &mut R) -> io::Result<BoxHeader> {
     Ok(BoxHeader { name: String::from_utf8_lossy(&name_buf).into_owned(), size, header_size })
 }
 
+/// Read the `moov` box of an MP4 file and return basic [`Metadata`].
+///
+/// This helper is used by the binary in `main.rs` to demonstrate metadata
+/// extraction.
 pub fn read_mp4_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     let file = File::open(&path)?;
     let size = file.metadata()?.len();


### PR DESCRIPTION
## Summary
- implement simple binary that prints MP4 metadata
- expose documentation comments for metadata extraction

## Testing
- `cargo test --manifest-path rust/mp4ff-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684b500cc2b8832bb6c40d16ace6a2ff