### PR TITLE
Add tx3g subtitle parser

### DIFF
--- a/rust/mp4ff-rs/src/bin/subs2vtt.rs
+++ b/rust/mp4ff-rs/src/bin/subs2vtt.rs
@@ -1,0 +1,57 @@
+use std::env;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use mp4ff::subs::{self, SubtitleVariant};
+
+fn timestamp(ts: u64, timescale: u32) -> String {
+    let millis = ts * 1000 / timescale as u64;
+    let h = millis / 3_600_000;
+    let m = (millis % 3_600_000) / 60_000;
+    let s = (millis % 60_000) / 1000;
+    let ms = millis % 1000;
+    format!("{:02}:{:02}:{:02}.{:03}", h, m, s, ms)
+}
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <mp4 file>", args[0]);
+        return Ok(());
+    }
+    let mut file = File::open(&args[1])?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)?;
+
+    let track = match subs::find_wvtt_track(&data) {
+        Ok(t) => t,
+        Err(_) => match subs::find_stpp_track(&data) {
+            Ok(t) => t,
+            Err(_) => match subs::find_tx3g_track(&data) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("{e}");
+                    return Ok(());
+                }
+            },
+        },
+    };
+
+    let out_path = Path::new(&args[1]).with_extension("vtt");
+    let mut out = File::create(out_path)?;
+    writeln!(out, "WEBVTT\n")?;
+    for (i, sample) in track.samples.iter().enumerate() {
+        let start = timestamp(sample.start, track.timescale);
+        let end = timestamp(sample.start + sample.dur as u64, track.timescale);
+        writeln!(out, "{}", i + 1)?;
+        writeln!(out, "{} --> {}", start, end)?;
+        if let Some(text) = subs::extract_text(track.variant, &sample.bytes) {
+            writeln!(out, "{}\n", text)?;
+        } else {
+            writeln!(out, "[binary]\n")?;
+        }
+    }
+    Ok(())
+}
+

--- a/rust/mp4ff-rs/src/bin/subslister.rs
+++ b/rust/mp4ff-rs/src/bin/subslister.rs
@@ -19,18 +19,22 @@ fn main() -> io::Result<()> {
         Ok(t) => t,
         Err(_) => match subs::find_stpp_track(&data) {
             Ok(t) => t,
-            Err(e) => {
-                eprintln!("{e}");
-                return Ok(());
-            }
+            Err(_) => match subs::find_tx3g_track(&data) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("{e}");
+                    return Ok(());
+                }
+            },
         },
     };
 
     for (i, sample) in track.samples.iter().enumerate() {
         println!("Sample {}", i + 1);
         match track.variant {
-            SubtitleVariant::Wvtt => subs::print_wvtt_sample(sample),
-            SubtitleVariant::Stpp => subs::print_stpp_sample(sample),
+            SubtitleVariant::Wvtt => subs::print_wvtt_sample(&sample.bytes),
+            SubtitleVariant::Stpp => subs::print_stpp_sample(&sample.bytes),
+            SubtitleVariant::Tx3g => subs::print_tx3g_sample(&sample.bytes),
         }
     }
     Ok(())

--- a/rust/mp4ff-rs/src/subs.rs
+++ b/rust/mp4ff-rs/src/subs.rs
@@ -7,12 +7,27 @@ pub enum SubtitleVariant {
     Wvtt,
     /// TTML subtitles (stpp)
     Stpp,
+    /// 3GPP timed text (tx3g)
+    Tx3g,
 }
 
 /// A subtitle track and its extracted samples
+/// Single subtitle sample with timing information
+pub struct Sample {
+    /// Raw bytes of the subtitle sample
+    pub bytes: Vec<u8>,
+    /// Decode time (start) in track timescale units
+    pub start: u64,
+    /// Duration in track timescale units
+    pub dur: u32,
+}
+
+/// Subtitle track consisting of all extracted samples
 pub struct Track {
     pub variant: SubtitleVariant,
-    pub samples: Vec<Vec<u8>>,
+    /// Timescale from the track `mdhd` box
+    pub timescale: u32,
+    pub samples: Vec<Sample>,
 }
 
 fn read_u32(data: &[u8], pos: &mut usize) -> Option<u32> {
@@ -57,6 +72,29 @@ fn parse_box_header(data: &[u8], pos: &mut usize) -> Option<(String, u64)> {
     Some((str::from_utf8(name).ok()?.to_string(), real_size))
 }
 
+fn parse_mdhd_timescale(mdhd: &[u8]) -> Option<u32> {
+    if mdhd.len() < 12 { return None; }
+    let mut p = 0usize;
+    let ver = mdhd[p];
+    p += if ver == 1 { 4 + 8 + 8 } else { 4 + 4 + 4 };
+    if p + 4 > mdhd.len() { return None; }
+    let ts = u32::from_be_bytes([mdhd[p], mdhd[p+1], mdhd[p+2], mdhd[p+3]]);
+    Some(ts)
+}
+
+fn parse_stts_entries(stts: &[u8]) -> Option<Vec<(u32, u32)>> {
+    if stts.len() < 8 { return None; }
+    let mut p = 4; // version+flags
+    let entry_count = read_u32(stts, &mut p)? as usize;
+    let mut entries = Vec::with_capacity(entry_count);
+    for _ in 0..entry_count {
+        let count = read_u32(stts, &mut p)?;
+        let delta = read_u32(stts, &mut p)?;
+        entries.push((count, delta));
+    }
+    Some(entries)
+}
+
 fn find_box<'a>(data: &'a [u8], name: &str) -> Option<&'a [u8]> {
     let (_, start, end) = find_box_range(data, name)?;
     Some(&data[start..end])
@@ -82,6 +120,10 @@ pub fn find_wvtt_track(data: &[u8]) -> Result<Track, &'static str> {
 
 pub fn find_stpp_track(data: &[u8]) -> Result<Track, &'static str> {
     find_track_inner(data, SubtitleVariant::Stpp).ok_or("no stpp track")
+}
+
+pub fn find_tx3g_track(data: &[u8]) -> Result<Track, &'static str> {
+    find_track_inner(data, SubtitleVariant::Tx3g).ok_or("no tx3g track")
 }
 
 fn find_track_inner(data: &[u8], variant: SubtitleVariant) -> Option<Track> {
@@ -114,7 +156,15 @@ fn parse_trak(root: &[u8], data: &[u8], variant: SubtitleVariant) -> Option<Trac
         SubtitleVariant::Stpp => {
             if handler != b"subt" { return None; }
         }
+        SubtitleVariant::Tx3g => {
+            if handler != b"sbtl" && handler != b"text" && handler != b"subt" {
+                return None;
+            }
+        }
     }
+    let mdhd = find_box(mdia, "mdhd")?;
+    let timescale = parse_mdhd_timescale(mdhd)?;
+
     let minf = find_box(mdia, "minf")?;
     let stbl = find_box(minf, "stbl")?;
     let stsd = find_box(stbl, "stsd")?;
@@ -125,6 +175,9 @@ fn parse_trak(root: &[u8], data: &[u8], variant: SubtitleVariant) -> Option<Trac
         SubtitleVariant::Stpp => {
             if !stsd.windows(4).any(|w| w == b"stpp") { return None; }
         }
+        SubtitleVariant::Tx3g => {
+            if !stsd.windows(4).any(|w| w == b"tx3g") { return None; }
+        }
     }
     let stsz = find_box(stbl, "stsz")?;
     // chunk offsets may use either 32- or 64-bit entries
@@ -134,8 +187,9 @@ fn parse_trak(root: &[u8], data: &[u8], variant: SubtitleVariant) -> Option<Trac
         (find_box(stbl, "co64")?, true)
     };
     let stsc = find_box(stbl, "stsc")?;
+    let stts = find_box(stbl, "stts")?;
 
-    // Simple parsing with assumption 1 sample per chunk and single stsc entry
+    // Parse stsz table with sample sizes
     let mut p = 4; // skip version+flags
     let sample_uniform = read_u32(stsz, &mut p)?;
     let sample_count = read_u32(stsz, &mut p)? as usize;
@@ -148,43 +202,93 @@ fn parse_trak(root: &[u8], data: &[u8], variant: SubtitleVariant) -> Option<Trac
         for _ in 0..sample_count { sizes.push(sample_uniform); }
     }
 
-    let mut p = 4; // stco/co64 version+flags
+    // Parse chunk offsets (stco/co64)
+    let mut p = 4; // version+flags
     let entry_count = read_u32(stco, &mut p)? as usize;
-    let mut offsets = Vec::with_capacity(entry_count);
+    let mut chunk_offsets = Vec::with_capacity(entry_count);
     for _ in 0..entry_count {
         let off = if use_co64 {
             read_u64(stco, &mut p)?
         } else {
             read_u32(stco, &mut p)? as u64
         };
-        offsets.push(off);
+        chunk_offsets.push(off);
     }
 
-    let mut p = 4; // stsc version+flags
-    let entries = read_u32(stsc, &mut p)? as usize;
-    if entries != 1 { return None; }
-    let first_chunk = read_u32(stsc, &mut p)?;
-    let samples_per_chunk = read_u32(stsc, &mut p)?;
-    if first_chunk != 1 || samples_per_chunk != 1 { return None; }
-    let _desc = read_u32(stsc, &mut p)?;
+    // Parse stsc entries
+    let mut p = 4; // version+flags
+    let entry_count = read_u32(stsc, &mut p)? as usize;
+    let mut stsc_entries = Vec::with_capacity(entry_count);
+    for _ in 0..entry_count {
+        let first_chunk = read_u32(stsc, &mut p)?;
+        let samples_per_chunk = read_u32(stsc, &mut p)?;
+        let desc_index = read_u32(stsc, &mut p)?;
+        stsc_entries.push((first_chunk, samples_per_chunk, desc_index));
+    }
 
-    if offsets.len() != sizes.len() { return None; }
+    // Parse stts entries for timing
+    let stts_entries = parse_stts_entries(stts)?;
+    let mut durations = Vec::new();
+    for (count, delta) in stts_entries {
+        for _ in 0..count { durations.push(delta); }
+    }
+    if durations.len() != sizes.len() { return None; }
 
     let (_, mdat_payload_start, mdat_end) = find_box_range(root, "mdat")?;
     let mdat_slice = &root[mdat_payload_start..mdat_end];
     Some(Track{
         variant,
-        samples: collect_samples(mdat_slice, mdat_payload_start as u64, &offsets, &sizes),
+        timescale,
+        samples: collect_samples_general(
+            mdat_slice,
+            mdat_payload_start as u64,
+            &chunk_offsets,
+            &stsc_entries,
+            &sizes,
+            &durations,
+        ),
     })
 }
 
-fn collect_samples(mdat: &[u8], base_offset: u64, offsets: &[u64], sizes: &[u32]) -> Vec<Vec<u8>> {
+fn collect_samples_general(
+    mdat: &[u8],
+    base_offset: u64,
+    chunk_offsets: &[u64],
+    stsc_entries: &[(u32, u32, u32)],
+    sizes: &[u32],
+    durs: &[u32],
+) -> Vec<Sample> {
     let mut samples = Vec::new();
-    for (&off, &size) in offsets.iter().zip(sizes.iter()) {
-        if off < base_offset { continue; }
-        let start = (off - base_offset) as usize;
-        let end = start + size as usize;
-        if end <= mdat.len() { samples.push(mdat[start..end].to_vec()); }
+    let mut sample_index = 0usize;
+    let mut decode_time = 0u64;
+    for (i, &(first_chunk, samples_per_chunk, _)) in stsc_entries.iter().enumerate() {
+        let next_first_chunk = stsc_entries
+            .get(i + 1)
+            .map(|e| e.0)
+            .unwrap_or(chunk_offsets.len() as u32 + 1);
+        for chunk in first_chunk..next_first_chunk {
+            let chunk_offset = chunk_offsets[(chunk - 1) as usize];
+            let mut offset_in_chunk = 0u64;
+            for _ in 0..samples_per_chunk {
+                if sample_index >= sizes.len() { break; }
+                let size = sizes[sample_index] as usize;
+                let absolute = chunk_offset + offset_in_chunk;
+                if absolute >= base_offset {
+                    let start = (absolute - base_offset) as usize;
+                    let end = start + size;
+                    if end <= mdat.len() {
+                        samples.push(Sample {
+                            bytes: mdat[start..end].to_vec(),
+                            start: decode_time,
+                            dur: durs[sample_index],
+                        });
+                    }
+                }
+                offset_in_chunk += size as u64;
+                decode_time += durs[sample_index] as u64;
+                sample_index += 1;
+            }
+        }
     }
     samples
 }
@@ -211,5 +315,58 @@ pub fn print_stpp_sample(sample: &[u8]) {
         println!("  {}", text);
     } else {
         println!("  [binary {} bytes]", sample.len());
+    }
+}
+
+pub fn print_tx3g_sample(sample: &[u8]) {
+    if sample.len() < 2 {
+        println!("  [binary {} bytes]", sample.len());
+        return;
+    }
+    let len = u16::from_be_bytes([sample[0], sample[1]]) as usize;
+    let end = 2 + len.min(sample.len() - 2);
+    let text = &sample[2..end];
+    if let Ok(s) = std::str::from_utf8(text) {
+        println!("  {}", s);
+    } else {
+        println!("  [binary {} bytes]", sample.len());
+    }
+}
+
+fn extract_wvtt_text(sample: &[u8]) -> Option<String> {
+    let mut pos = 0usize;
+    while pos + 8 <= sample.len() {
+        let start = pos;
+        if let Some((name, size)) = parse_box_header(sample, &mut pos) {
+            if size as usize > sample.len() - start { break; }
+            let payload = &sample[pos..start + size as usize];
+            if name == "payl" {
+                if let Ok(text) = std::str::from_utf8(payload) {
+                    return Some(text.to_string());
+                }
+            }
+            pos = start + size as usize;
+        } else { break; }
+    }
+    None
+}
+
+fn extract_stpp_text(sample: &[u8]) -> Option<String> {
+    std::str::from_utf8(sample).ok().map(|s| s.to_string())
+}
+
+fn extract_tx3g_text(sample: &[u8]) -> Option<String> {
+    if sample.len() < 2 { return None; }
+    let len = u16::from_be_bytes([sample[0], sample[1]]) as usize;
+    let end = 2 + len.min(sample.len() - 2);
+    std::str::from_utf8(&sample[2..end]).ok().map(|s| s.to_string())
+}
+
+/// Decode subtitle sample text depending on variant
+pub fn extract_text(variant: SubtitleVariant, sample: &[u8]) -> Option<String> {
+    match variant {
+        SubtitleVariant::Wvtt => extract_wvtt_text(sample),
+        SubtitleVariant::Stpp => extract_stpp_text(sample),
+        SubtitleVariant::Tx3g => extract_tx3g_text(sample),
     }
 }


### PR DESCRIPTION
## Summary
- extend subtitle parser library to support `tx3g` subtitles
- support detection and printing of `tx3g` samples
- update `subslister` example to handle `tx3g`
- parse subtitle timing info and support `.vtt` extraction
- add new `subs2vtt` binary to create `.vtt` files

## Testing
- `cargo build --quiet`
- `cargo test --quiet`
- `cargo run --quiet --bin subslister ../../mediaFile/video_subtitle.mp4 | head -n 5`
- `cargo run --quiet --bin subs2vtt ../../mediaFile/video_subtitle.mp4 && head ../../mediaFile/video_subtitle.vtt`


------
https://chatgpt.com/codex/tasks/task_e_684bf3237c2c832ba9ee64781f78537a