### PR TITLE
Add simple AVC parser modules

### DIFF
--- a/rust/mp4ff-rs/src/avc/decconf.rs
+++ b/rust/mp4ff-rs/src/avc/decconf.rs
@@ -1,0 +1,52 @@
+
+/// AVCDecoderConfigurationRecord extracted from avcC box.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecConfRec {
+    pub profile_indication: u8,
+    pub profile_compatibility: u8,
+    pub level_indication: u8,
+    pub sps: Vec<Vec<u8>>,
+    pub pps: Vec<Vec<u8>>,
+}
+
+/// Parse the AVCDecoderConfigurationRecord as defined in ISO/IEC 14496-15.
+pub fn decode_avc_decoder_config(data: &[u8]) -> Option<DecConfRec> {
+    if data.len() < 6 { return None; }
+    if data[0] != 1 { return None; }
+    let profile = data[1];
+    let compat = data[2];
+    let level = data[3];
+    let length_size_minus1 = data[4] & 0x03;
+    if length_size_minus1 != 3 { return None; }
+    let mut pos = 5usize;
+    let num_sps = data[pos] & 0x1f;
+    pos += 1;
+    let mut sps_vec = Vec::new();
+    for _ in 0..num_sps {
+        if pos + 2 > data.len() { return None; }
+        let len = u16::from_be_bytes([data[pos], data[pos+1]]) as usize;
+        pos += 2;
+        if pos + len > data.len() { return None; }
+        sps_vec.push(data[pos..pos+len].to_vec());
+        pos += len;
+    }
+    if pos >= data.len() { return None; }
+    let num_pps = data[pos];
+    pos += 1;
+    let mut pps_vec = Vec::new();
+    for _ in 0..num_pps {
+        if pos + 2 > data.len() { return None; }
+        let len = u16::from_be_bytes([data[pos], data[pos+1]]) as usize;
+        pos += 2;
+        if pos + len > data.len() { return None; }
+        pps_vec.push(data[pos..pos+len].to_vec());
+        pos += len;
+    }
+    Some(DecConfRec {
+        profile_indication: profile,
+        profile_compatibility: compat,
+        level_indication: level,
+        sps: sps_vec,
+        pps: pps_vec,
+    })
+}

--- a/rust/mp4ff-rs/src/avc/mod.rs
+++ b/rust/mp4ff-rs/src/avc/mod.rs
@@ -1,0 +1,118 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NaluType {
+    NonIDR = 1,
+    IDR = 5,
+    SEI = 6,
+    SPS = 7,
+    PPS = 8,
+    AUD = 9,
+    EOSeq = 10,
+    EOStream = 11,
+    Fill = 12,
+    Other(u8),
+}
+
+impl NaluType {
+    pub fn from_header_byte(b: u8) -> Self {
+        match b & 0x1f {
+            1 => NaluType::NonIDR,
+            5 => NaluType::IDR,
+            6 => NaluType::SEI,
+            7 => NaluType::SPS,
+            8 => NaluType::PPS,
+            9 => NaluType::AUD,
+            10 => NaluType::EOSeq,
+            11 => NaluType::EOStream,
+            12 => NaluType::Fill,
+            v => NaluType::Other(v),
+        }
+    }
+
+    pub fn is_video(&self) -> bool {
+        matches!(self, NaluType::NonIDR | NaluType::IDR)
+    }
+}
+
+pub fn find_nalu_types(sample: &[u8]) -> Vec<NaluType> {
+    if sample.len() < 4 { return Vec::new(); }
+    let mut pos = 0usize;
+    let mut nalus = Vec::new();
+    while pos + 4 <= sample.len() {
+        let len = u32::from_be_bytes([sample[pos], sample[pos+1], sample[pos+2], sample[pos+3]]) as usize;
+        pos += 4;
+        if pos >= sample.len() { break; }
+        let ntype = NaluType::from_header_byte(sample[pos]);
+        nalus.push(ntype);
+        pos += len;
+    }
+    nalus
+}
+
+pub fn has_parameter_sets(sample: &[u8]) -> bool {
+    let types = find_nalu_types_up_to_first_video(sample);
+    let mut has_sps = false;
+    let mut has_pps = false;
+    for t in types {
+        if t == NaluType::SPS { has_sps = true; }
+        if t == NaluType::PPS { has_pps = true; }
+        if has_sps && has_pps { return true; }
+    }
+    false
+}
+
+pub fn find_nalu_types_up_to_first_video(sample: &[u8]) -> Vec<NaluType> {
+    if sample.len() < 4 { return Vec::new(); }
+    let mut pos = 0usize;
+    let mut nalus = Vec::new();
+    while pos + 4 <= sample.len() {
+        let len = u32::from_be_bytes([sample[pos], sample[pos+1], sample[pos+2], sample[pos+3]]) as usize;
+        pos += 4;
+        if pos >= sample.len() { break; }
+        let ntype = NaluType::from_header_byte(sample[pos]);
+        nalus.push(ntype);
+        pos += len;
+        if ntype.is_video() { break; }
+    }
+    nalus
+}
+
+pub fn contains_nalu_type(sample: &[u8], ntype: NaluType) -> bool {
+    let mut pos = 0usize;
+    while pos + 4 <= sample.len() {
+        let len = u32::from_be_bytes([sample[pos], sample[pos+1], sample[pos+2], sample[pos+3]]) as usize;
+        pos += 4;
+        if pos >= sample.len() { break; }
+        if NaluType::from_header_byte(sample[pos]) == ntype { return true; }
+        pos += len;
+    }
+    false
+}
+
+pub fn get_parameter_sets(sample: &[u8]) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    let mut sps = Vec::new();
+    let mut pps = Vec::new();
+    if sample.len() < 4 { return (sps, pps); }
+    let mut pos = 0usize;
+    while pos + 4 <= sample.len() {
+        let len = u32::from_be_bytes([sample[pos], sample[pos+1], sample[pos+2], sample[pos+3]]) as usize;
+        pos += 4;
+        if pos >= sample.len() { break; }
+        let ntype = NaluType::from_header_byte(sample[pos]);
+        let end = std::cmp::min(pos + len, sample.len());
+        match ntype {
+            NaluType::SPS => sps.push(sample[pos..end].to_vec()),
+            NaluType::PPS => pps.push(sample[pos..end].to_vec()),
+            _ if ntype.is_video() => break,
+            _ => {}
+        }
+        pos += len;
+    }
+    (sps, pps)
+}
+
+pub mod sps;
+pub mod decconf;
+
+pub use sps::{Sps, parse_sps_nalu};
+pub use decconf::{DecConfRec, decode_avc_decoder_config};

--- a/rust/mp4ff-rs/src/avc/sps.rs
+++ b/rust/mp4ff-rs/src/avc/sps.rs
@@ -1,0 +1,121 @@
+use std::io::Cursor;
+
+use crate::bits::reader::BitReader;
+
+use super::NaluType;
+
+/// Parsed information from an SPS NAL unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sps {
+    pub profile: u8,
+    pub level: u8,
+    pub width: u16,
+    pub height: u16,
+}
+
+/// Parse an SPS NAL unit (including the NAL header) and return width and height.
+/// The parsing is intentionally limited and ignores most fields.
+pub fn parse_sps_nalu(nalu: &[u8]) -> Option<Sps> {
+    if nalu.is_empty() { return None; }
+    if NaluType::from_header_byte(nalu[0]) != NaluType::SPS { return None; }
+    let bytes = remove_emulation_prevention_bytes(&nalu[1..]);
+    let mut r = BitReader::new(Cursor::new(bytes));
+    let profile_idc = r.read(8) as u8;
+    let _compat = r.read(8);
+    let level_idc = r.read(8) as u8;
+    let _id = read_ue(&mut r);
+    let mut chroma_format_idc = 1u32;
+    match profile_idc {
+        100 | 110 | 122 | 244 | 44 | 83 | 86 | 118 | 128 | 138 | 139 | 134 | 135 => {
+            chroma_format_idc = read_ue(&mut r);
+            if chroma_format_idc == 3 { r.read(1); }
+            let _ = read_ue(&mut r); // bit_depth_luma_minus8
+            let _ = read_ue(&mut r); // bit_depth_chroma_minus8
+            r.read(1); // qpprime_y_zero_transform_bypass_flag
+            if r.read(1) == 1 { // seq_scaling_matrix_present_flag
+                let lists = if chroma_format_idc != 3 { 8 } else { 12 };
+                for i in 0..lists { if r.read(1) == 1 { read_scaling_list(&mut r, if i < 6 { 16 } else { 64 }); } }
+            }
+        }
+        _ => {}
+    }
+    let _ = read_ue(&mut r); // log2_max_frame_num_minus4
+    let pic_order_cnt_type = read_ue(&mut r);
+    if pic_order_cnt_type == 0 {
+        let _ = read_ue(&mut r); // log2_max_pic_order_cnt_lsb_minus4
+    } else if pic_order_cnt_type == 1 {
+        r.read(1); // delta_pic_order_always_zero_flag
+        let _ = read_se(&mut r); // offset_for_non_ref_pic
+        let _ = read_se(&mut r); // offset_for_top_to_bottom_field
+        let num = read_ue(&mut r);
+        for _ in 0..num { let _ = read_se(&mut r); }
+    }
+    let _ = read_ue(&mut r); // num_ref_frames
+    r.read(1); // gaps_in_frame_num_value_allowed_flag
+    let width_in_mbs = read_ue(&mut r) + 1;
+    let height_in_map = read_ue(&mut r) + 1;
+    let frame_mbs_only_flag = r.read(1);
+    let mut width = width_in_mbs * 16;
+    let mut height = height_in_map * 16;
+    if frame_mbs_only_flag == 0 { r.read(1); height *= 2; }
+    r.read(1); // direct_8x8_inference_flag
+    let cropping_flag = r.read(1);
+    let mut crop_left = 0u32;
+    let mut crop_right = 0u32;
+    let mut crop_top = 0u32;
+    let mut crop_bottom = 0u32;
+    if cropping_flag == 1 {
+        crop_left = read_ue(&mut r);
+        crop_right = read_ue(&mut r);
+        crop_top = read_ue(&mut r);
+        crop_bottom = read_ue(&mut r);
+    }
+    let (crop_unit_x, crop_unit_y) = match chroma_format_idc {
+        0 => (1, 2 - frame_mbs_only_flag as u32),
+        1 => (2, 2 * (2 - frame_mbs_only_flag as u32)),
+        2 => (2, 1 * (2 - frame_mbs_only_flag as u32)),
+        _ => (1, 1 * (2 - frame_mbs_only_flag as u32)),
+    };
+    width -= (crop_left + crop_right) * crop_unit_x;
+    height -= (crop_top + crop_bottom) * crop_unit_y;
+    Some(Sps { profile: profile_idc, level: level_idc, width: width as u16, height: height as u16 })
+}
+
+fn read_ue<R: std::io::Read>(r: &mut BitReader<R>) -> u32 {
+    let mut leading = 0u32;
+    while r.read(1) == 0 { if r.acc_error().is_some() { return 0; } leading += 1; }
+    let prefix = (1u32 << leading) - 1;
+    let suffix = if leading > 0 { r.read(leading) } else { 0 };
+    prefix + suffix
+}
+
+fn read_se<R: std::io::Read>(r: &mut BitReader<R>) -> i32 {
+    let ue = read_ue(r) as i32;
+    if ue % 2 == 1 { (ue + 1) / 2 } else { -(ue / 2) }
+}
+
+fn read_scaling_list<R: std::io::Read>(r: &mut BitReader<R>, size: usize) {
+    let mut last_scale = 8i32;
+    let mut next_scale = 8i32;
+    for _ in 0..size {
+        if next_scale != 0 {
+            let delta = read_se(r);
+            next_scale = (last_scale + delta + 256) % 256;
+        }
+        if next_scale == 0 { last_scale = last_scale; } else { last_scale = next_scale; }
+    }
+}
+
+fn remove_emulation_prevention_bytes(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut zero_count = 0u8;
+    for &b in data {
+        if zero_count == 2 && b == 0x03 {
+            zero_count = 0;
+            continue;
+        }
+        out.push(b);
+        if b == 0 { zero_count += 1; } else { zero_count = 0; }
+    }
+    out
+}

--- a/rust/mp4ff-rs/src/lib.rs
+++ b/rust/mp4ff-rs/src/lib.rs
@@ -13,6 +13,8 @@ pub use videoinfo::{VideoInfo, read_mp4_video_info};
 
 pub mod mp4;
 
+pub mod avc;
+
 pub mod subs;
 pub use subs::*;
 


### PR DESCRIPTION
## Summary
- implement `sps` parser in Rust to obtain frame size from SPS NALUs
- implement `decconf` parser for AVCDecoderConfigurationRecord
- expose new parser helpers via the `avc` module

## Testing
- `cargo check`
- `cargo test`
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b03c13ae4832b9dca95a7cfcf45e5