### PR TITLE
Fix unused import in thumbnail example

### DIFF
--- a/rust/mp4ff-rs/src/bin/thumbnail.rs
+++ b/rust/mp4ff-rs/src/bin/thumbnail.rs
@@ -5,7 +5,7 @@
 //! directly so the file is self contained.
 
 
-use mp4ff::{DecodedYUV, Decoder, H264Error};
+use mp4ff::{Decoder, H264Error};
 
 use image::RgbImage;
 use std::fs::File;

--- a/rust/mp4ff-rs/src/h264decoder.rs
+++ b/rust/mp4ff-rs/src/h264decoder.rs
@@ -191,23 +191,15 @@ impl DynamicAPI {
 
 /// Simple error wrapper used by the examples.
 #[derive(Debug)]
-pub struct H264Error(Box<dyn std::error::Error>);
+pub struct H264Error(Box<dyn std::error::Error + Send + Sync>);
 
 
 impl<E> From<E> for H264Error
 where
-    E: std::error::Error + 'static,
-    E: 'static,
-    E: std::fmt::Debug + std::fmt::Display,
-    E: Send + Sync,
-    E: std::any::Any,
-    E: Into<Box<dyn std::error::Error + Send + Sync>>,
-    E: std::cmp::PartialEq + std::cmp::Eq,
-    E: std::marker::Sized,
-    E: std::ops::Not<Output = bool>, // hack para evitar recursão reflexiva
+    E: std::error::Error + Send + Sync + 'static,
 {
     fn from(e: E) -> Self {
-        Self(e.into())
+        Self(Box::new(e))
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unused `DecodedYUV` import in `thumbnail.rs`
- simplify `H264Error` conversion bounds so `?` works in example

## Testing
- `cargo test --all --offline` *(fails: could not fetch `image` crate)*

------
https://chatgpt.com/codex/tasks/task_e_685c7dd2f2e4832ba003f930a4ab058f