### PR TITLE
Remove image dependency and convert thumbnail to PPM

### DIFF
--- a/rust/mp4ff-rs/Cargo.toml
+++ b/rust/mp4ff-rs/Cargo.toml
@@ -8,4 +8,12 @@ license = "MIT"
 name = "mp4ff"
 
 [dependencies]
-image = "0.24"
+
+[features]
+default = []
+openh264 = []
+
+[[example]]
+name = "thumbnail"
+path = "examples/thumbnail.rs"
+required-features = ["openh264"]

--- a/rust/mp4ff-rs/src/avc/simple.rs
+++ b/rust/mp4ff-rs/src/avc/simple.rs
@@ -1,5 +1,28 @@
-use image::{RgbImage, Rgb};
 use super::sps::Sps;
+
+/// Minimal RGB image used only for this stub implementation.
+pub struct RgbImage {
+    /// Pixel data in RGB format.
+    pub data: Vec<u8>,
+    /// Width of the image in pixels.
+    pub width: u32,
+    /// Height of the image in pixels.
+    pub height: u32,
+}
+
+impl RgbImage {
+    /// Create an image filled with a single RGB color.
+    pub fn from_pixel(width: u32, height: u32, pixel: Rgb) -> Self {
+        let mut data = Vec::with_capacity((width * height * 3) as usize);
+        for _ in 0..(width * height) {
+            data.extend_from_slice(&pixel.0);
+        }
+        Self { data, width, height }
+    }
+}
+
+/// Simple RGB triplet used by [`RgbImage`].
+pub struct Rgb(pub [u8; 3]);
 
 /// Decode an IDR slice to RGB. This is a stub implementation which
 /// simply returns a black frame with the size specified in the SPS.

--- a/rust/mp4ff-rs/src/h264decoder.rs
+++ b/rust/mp4ff-rs/src/h264decoder.rs
@@ -191,23 +191,12 @@ impl DynamicAPI {
 
 /// Simple error wrapper used by the examples.
 #[derive(Debug)]
-pub struct H264Error(Box<dyn std::error::Error>);
+pub struct H264Error(Box<dyn std::error::Error + Send + Sync>);
 
 
-impl<E> From<E> for H264Error
-where
-    E: std::error::Error + 'static,
-    E: 'static,
-    E: std::fmt::Debug + std::fmt::Display,
-    E: Send + Sync,
-    E: std::any::Any,
-    E: Into<Box<dyn std::error::Error + Send + Sync>>,
-    E: std::cmp::PartialEq + std::cmp::Eq,
-    E: std::marker::Sized,
-    E: std::ops::Not<Output = bool>, // hack para evitar recursão reflexiva
-{
-    fn from(e: E) -> Self {
-        Self(e.into())
+impl From<std::io::Error> for H264Error {
+    fn from(e: std::io::Error) -> Self {
+        Self(Box::new(e))
     }
 }
 
@@ -221,7 +210,7 @@ impl std::error::Error for H264Error {}
 
 impl H264Error {
     pub fn msg(msg: &str) -> Self {
-        Self(msg.to_string().into())
+        Self(Box::new(std::io::Error::new(std::io::ErrorKind::Other, msg)))
     }
 }
 


### PR DESCRIPTION
## Summary
- drop `image` crate and introduce `openh264` feature gated example
- implement a tiny RGB image type in `avc::simple`
- simplify `H264Error` to convert only from `std::io::Error`
- update thumbnail example to output PPM using `DecodedYUV`

## Testing
- `cargo test --all --offline`

------
https://chatgpt.com/codex/tasks/task_e_685c7dd2f2e4832ba003f930a4ab058f