### PR TITLE
Simplify track_server streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run the server with your MP4 file:
 ```bash
 cargo run --bin track_server path/to/video.mp4
 ```
-Open `http://localhost:8080/track.html` in a browser or open `http://localhost:8080/video.h264` directly in VLC.
+Open `http://localhost:8080/video.h264` in VLC or another player that can stream raw H.264.
 
 ## Packages
 


### PR DESCRIPTION
## Summary
- update `track_server` so only `video.h264` is served and all other paths return 404
- adjust documentation for new server behaviour

## Testing
- `cargo test --quiet` *(fails: download of config.json failed)*
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685df3f0e708832bbfa1f66b3477bb65