### PR TITLE
Add MP4 serving in track_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ The examples and their functions are:
 4. [multitrack](examples/multitrack) parses a fragmented file with multiple tracks
 5. [combine-segs](examples/combine-segs) combines single-track init and media segments into multi-track segments
 6. [add-sidx](examples/add-sidx) adds a top-level sidx box describing the segments of a fragmented files.
-7. `track_server` in `rust/mp4ff-rs` serves the H.264 track from an MP4 over HTTP.
+7. `track_server` in `rust/mp4ff-rs` serves both the original MP4 file and its
+   H.264 track over HTTP.
 8. `thumbnail` in `rust/mp4ff-rs` parses the video track and writes a PNG thumbnail at five seconds using a very small built‑in decoder.
 
 ### Running the Rust track server
@@ -62,7 +63,9 @@ Run the server with your MP4 file:
 ```bash
 cargo run --bin track_server path/to/video.mp4
 ```
-Open `http://localhost:8080/video.h264` in VLC or another player that can stream raw H.264.
+Open `http://localhost:8080/video.mp4` in a browser or media player to fetch the original file.
+For a raw H.264 stream compatible with `ffplay` or VLC, use
+`http://localhost:8080/video.h264`.
 
 ## Packages
 


### PR DESCRIPTION
## Summary
- serve loaded MP4 file with `video/mp4` when path ends with `video.mp4`
- keep `.h264` handling for ffplay
- return 404 for other paths
- document both endpoints in README

## Testing
- `cargo build --bin track_server` *(fails: download of config.json failed)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa0d81ac832bab06867a6dd243e8